### PR TITLE
Fix base path detection for Vercel

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,14 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  base: "/Data-Showcase/",
-  server: {
-    host: "::",
-    port: 8080,
-  },
+export default defineConfig(({ mode }) => {
+  const base = process.env.VERCEL ? '/' : '/Data-Showcase/';
+  return {
+    base,
+    server: {
+      host: "::",
+      port: 8080,
+    },
   plugins: [
     react(),
   ],
@@ -17,4 +19,5 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-}));
+  };
+});


### PR DESCRIPTION
## Summary
- detect Vercel environment in `vite.config.ts`
- use root base path when building on Vercel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
