### PR TITLE
Fix LA rental project images

### DIFF
--- a/src/projects/la-rental-post-fire/LARentalProject.tsx
+++ b/src/projects/la-rental-post-fire/LARentalProject.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/ui/button';
 import { Project } from '@/data/projects';       // or projectRegistry model
 import Footer from '@/components/Footer';
 import Navbar from '@/components/Navbar';
-import RentSeriesImg from '../../../LA-Fire-images/Rent-Series.png';
 import Plot from 'react-plotly.js';
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- update LA rental project images to use absolute `/Data-Showcase` paths

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
